### PR TITLE
refactor: Replace hardcoded SUPPORTED_PROVIDERS with dynamic provider mapping

### DIFF
--- a/src/celeste_document_intelligence/__init__.py
+++ b/src/celeste_document_intelligence/__init__.py
@@ -10,28 +10,23 @@ from celeste_core.config.settings import settings
 
 from .core.enums import MimeType
 from .core.types import Document
+from .mapping import PROVIDER_MAPPING
 
 __version__ = "0.1.0"
-
-SUPPORTED_PROVIDERS: set[Provider] = {Provider.GOOGLE}
 
 
 def create_doc_client(provider: str, **kwargs: Any) -> BaseDocClient:
     provider_enum = Provider(provider) if isinstance(provider, str) else provider
-    if provider_enum not in SUPPORTED_PROVIDERS:
+    if provider_enum not in PROVIDER_MAPPING:
         raise ValueError(f"Unsupported provider: {provider_enum}")
 
     # Validate environment for the chosen provider
     settings.validate_for_provider(provider_enum.value)
 
-    mapping = {
-        Provider.GOOGLE: (".providers.google", "GeminiDocClient"),
-    }
-
-    if provider_enum not in mapping:
+    if provider_enum not in PROVIDER_MAPPING:
         raise ValueError(f"No client mapping for provider: {provider_enum}")
 
-    module_path, class_name = mapping[provider_enum]
+    module_path, class_name = PROVIDER_MAPPING[provider_enum]
     module = __import__(
         f"celeste_document_intelligence{module_path}",
         fromlist=[class_name],

--- a/src/celeste_document_intelligence/mapping.py
+++ b/src/celeste_document_intelligence/mapping.py
@@ -1,0 +1,12 @@
+from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
+
+# Capability for this domain package
+CAPABILITY: Capability = Capability.DOCUMENT_INTELLIGENCE
+
+# Provider wiring for document intelligence clients
+PROVIDER_MAPPING: dict[Provider, tuple[str, str]] = {
+    Provider.GOOGLE: (".providers.google", "GeminiDocClient"),
+}
+
+__all__ = ["CAPABILITY", "PROVIDER_MAPPING"]


### PR DESCRIPTION
## Summary
• Remove hardcoded `SUPPORTED_PROVIDERS` set that only included Google provider
• Implement dynamic provider validation using `PROVIDER_MAPPING` from new `mapping.py` module  
• Enable extensible provider support architecture

## Test plan
- [ ] Verify existing Google provider functionality still works
- [ ] Confirm provider validation now uses PROVIDER_MAPPING
- [ ] Test that unsupported providers are properly rejected
- [ ] Ensure all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)