### PR TITLE
fix: Use consistent model attribute in Google provider

### DIFF
--- a/src/celeste_document_intelligence/providers/google.py
+++ b/src/celeste_document_intelligence/providers/google.py
@@ -37,7 +37,7 @@ class GeminiDocClient(BaseDocClient):
     ) -> AIResponse:
         """Generate text from a prompt and a list of documents."""
         response = await self.client.aio.models.generate_content(
-            model=self.model_name,
+            model=self.model,
             contents=[
                 prompt,
                 *[
@@ -53,7 +53,7 @@ class GeminiDocClient(BaseDocClient):
         return AIResponse(
             content=response.text,
             provider=Provider.GOOGLE,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -73,11 +73,11 @@ class GeminiDocClient(BaseDocClient):
         ]
 
         async for chunk in await self.client.aio.models.generate_content_stream(
-            model=self.model_name, contents=contents, config=config
+            model=self.model, contents=contents, config=config
         ):
             if chunk.text:  # Only yield if there's actual content
                 yield AIResponse(
                     content=chunk.text,
                     provider=Provider.GOOGLE,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )


### PR DESCRIPTION
## Summary
- Replace `self.model_name` with `self.model` throughout GeminiDocClient for consistent property naming
- Fixes attribute inconsistency that could cause issues in the Google provider implementation

## Test plan
- [ ] Verify all pre-commit hooks pass ✅
- [ ] Test Google provider functionality with various models
- [ ] Confirm no breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.ai/code)